### PR TITLE
change nft to view_nft

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,14 @@ Transfer NFT from specified `contract` on behalf of provided `enforce_owner_id` 
 View NFT (simple)
 ---
 
-GET `nft/{token_id}`
+GET `view_nft/{token_id}`
 
 Receive information about NFT
 
 Generic view NFT
 ---
 
-POST `nft`
+POST `view_nft`
 
 ```
 {

--- a/app.js
+++ b/app.js
@@ -118,7 +118,7 @@ const init = async () => {
 
     server.route({
         method: 'GET',
-        path: '/nft/{token_id}',
+        path: '/view_nft/{token_id}',
         handler: async (request) => {
             return await token.ViewNFT(request.params.token_id);
         }
@@ -126,7 +126,7 @@ const init = async () => {
 
     server.route({
         method: 'POST',
-        path: '/nft/',
+        path: '/view_nft/',
         handler: async (request) => {
             return await token.ViewNFT(request.payload.token_id, request.payload.contract);
         }


### PR DESCRIPTION
I think it might make sense to change `nft` to `view_nft` to help clarify the purpose of this endpoint. I created a table outlining endpoints for quick reference and I think it would be easier to navigate with this name.

---

![Screen Shot 2021-04-27 at 8 21 36 PM](https://user-images.githubusercontent.com/58483342/116341722-420ccc00-a796-11eb-9023-0478b3725450.png)

vs.

![Screen Shot 2021-04-27 at 8 21 56 PM](https://user-images.githubusercontent.com/58483342/116341694-391bfa80-a796-11eb-9e06-ae69af1d3cfa.png)


